### PR TITLE
Fire item tick even when resting

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -163,26 +163,26 @@ Game.prototype.addItem = function(item) {
       }
     }
     
-    if (item.resting) return
-    
-    var c = self.getCollisions(item.mesh.position, item)
-    if (c.bottom.length > 0) {
-      if (item.velocity.y <= 0) {
-        item.mesh.position.y -= item.velocity.y
-        item.velocity.y = 0
-        item.resting = true
+    if (!item.resting) {
+      var c = self.getCollisions(item.mesh.position, item)
+      if (c.bottom.length > 0) {
+        if (item.velocity.y <= 0) {
+          item.mesh.position.y -= item.velocity.y
+          item.velocity.y = 0
+          item.resting = true
+        }
+        item.velocity.x = 0
+        item.velocity.z = 0
+      } else if (c.middle.length || c.top.length) {
+        item.velocity.x *= -1
+        item.velocity.z *= -1
       }
-      item.velocity.x = 0
-      item.velocity.z = 0
-    } else if (c.middle.length || c.top.length) {
-      item.velocity.x *= -1
-      item.velocity.z *= -1
+
+      item.velocity.y -= 0.003
+      item.mesh.position.x += item.velocity.x * dt
+      item.mesh.position.y += item.velocity.y * dt
+      item.mesh.position.z += item.velocity.z * dt
     }
-    
-    item.velocity.y -= 0.003
-    item.mesh.position.x += item.velocity.x * dt
-    item.mesh.position.y += item.velocity.y * dt
-    item.mesh.position.z += item.velocity.z * dt
     
     if (ticker) ticker(item)
   }


### PR DESCRIPTION
This will allow `item.resting = false` to be set within the item's `tick`.

I'm building an ar drone sim. It reads raw AT\* commands from a browserified ar-drone lib. During the tick it checks one of the flurry of incoming commands for `AT*REF=1,512` to know when to hover and have `item.resting = false`.

Thank you!
