### PR TITLE
Use voxel-texture for texturing and different textured voxel meshes.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -19,7 +19,7 @@ var generator = function(low, high, x, y, z) {
 window.game = createGame({
   generateVoxelChunk: generator,
   texturePath: '/textures/',
-  materials: ['grass', 'brick', 'dirt', 'obsidian', 'crate'],
+  materials: [['grass', 'dirt', 'grass_dirt'], 'brick', 'dirt', 'obsidian', 'crate'],
   cubeSize: 25,
   chunkSize: 32,
   chunkDistance: 2,

--- a/lib/game.js
+++ b/lib/game.js
@@ -21,7 +21,7 @@ function Game(opts) {
       return voxel.generate(low, high, opts.generate)
     }
   } else this.generateVoxelChunk = opts.generateVoxelChunk
-  
+
   this.THREE = THREE
   this.texturePath = opts.texturePath || '/textures/'
   this.cubeSize = opts.cubeSize || 25
@@ -40,7 +40,7 @@ function Game(opts) {
   this.camera = this.createCamera(scene)
   this.controls = this.createControls()
   this.moveToPosition(this.startingPosition)
-  
+
   // client side only (todo: use better pattern than this)
   if (process.browser) {
     this.initializeRendering()
@@ -54,7 +54,11 @@ inherits(Game, EventEmitter)
 
 Game.prototype.initializeRendering = function() {
   var self = this
-  this.material = this.loadTextures(this.materials)
+  this._materialEngine = require('voxel-texture')({
+    texturePath: self.texturePath,
+    THREE: THREE
+  })
+  this.material = this._materialEngine.loadTextures(this.materials)
   this.renderer = this.createRenderer()
   this.addLights(this.scene)
   this.bindWASD(this.controls)
@@ -149,7 +153,7 @@ Game.prototype.addItem = function(item) {
   if (!item.width) item.width = item.size
   if (!item.height) item.height = item.size
   if (!item.depth) item.depth = item.width
-  
+
   var ticker = item.tick
   item.tick = function (dt) {
     if (item.collisionRadius) {
@@ -162,7 +166,7 @@ Game.prototype.addItem = function(item) {
         self.emit('collision', item)
       }
     }
-    
+
     if (!item.resting) {
       var c = self.getCollisions(item.mesh.position, item)
       if (c.bottom.length > 0) {
@@ -183,7 +187,7 @@ Game.prototype.addItem = function(item) {
       item.mesh.position.y += item.velocity.y * dt
       item.mesh.position.z += item.velocity.z * dt
     }
-    
+
     if (ticker) ticker(item)
   }
   self.scene.add(item.mesh)
@@ -232,22 +236,6 @@ Game.prototype.raycast = function() {
   var direction = this.camera.matrixWorld.multiplyVector3(new THREE.Vector3(0,0,-1))
   var intersects = this.intersectAllMeshes(start, direction)
   return intersects
-}
-
-Game.prototype.loadTextures = function(names) {
-  var self = this
-  return new THREE.MeshFaceMaterial(names.map(function (name) {
-    var tex = THREE.ImageUtils.loadTexture(self.texturePath + name + ".png")
-    tex.magFilter = THREE.NearestFilter
-    tex.minFilter = THREE.LinearMipMapLinearFilter
-    tex.wrapT = THREE.RepeatWrapping
-    tex.wrapS = THREE.RepeatWrapping
-    
-    return new THREE.MeshLambertMaterial({
-      map: tex,
-      ambient: 0xbbbbbb
-    })
-  }))
 }
 
 Game.prototype.createCamera = function() {
@@ -303,11 +291,11 @@ Game.prototype.getCollisions = function(position, dims, checker, controls) {
   var w = dims.width / 2
   var h = dims.height / 2
   var d = dims.depth / 2
-  
+
   controls = controls || this.controls
   var rx = controls.pitchObject.rotation.x
   var ry = controls.yawObject.rotation.y
-  
+
   var vertices = {
     bottom: [
       new THREE.Vector3(p.x - w, p.y - h, p.z - d),
@@ -340,7 +328,7 @@ Game.prototype.getCollisions = function(position, dims, checker, controls) {
         p.x + w * Math.cos(ry + Math.PI / 2),
         p.y + h * 1.5,
         p.z + d * Math.sin(ry + Math.PI / 2)
-      ) 
+      )
     ],
     right: [
       new THREE.Vector3(
@@ -392,7 +380,7 @@ Game.prototype.getCollisions = function(position, dims, checker, controls) {
     forward: vertices.forward.map(check).filter(Boolean),
     back: vertices.back.map(check).filter(Boolean)
   }
-  
+
   function check(vertex) {
     if (checker) return checker(vertex) && vertex
     var val = self.voxels.voxelAtPosition(vertex)
@@ -419,7 +407,7 @@ Game.prototype.checkBlock = function(pos) {
   var direction = self.camera.matrixWorld.multiplyVector3(new THREE.Vector3(0,0,-1))
   var start = self.controls.yawObject.position.clone()
   var d = direction.subSelf(start).normalize()
-  
+
   var p = new THREE.Vector3()
   p.copy(pos)
   p.x -= 1.1 * d.x
@@ -427,27 +415,27 @@ Game.prototype.checkBlock = function(pos) {
   p.z -= 1.1 * d.z
   var block = self.getBlock(p)
   if (block) return false
-  
+
   var voxelVector = self.voxels.voxelVector(p)
   var vidx = self.voxels.voxelIndex(voxelVector)
   var c = self.voxels.chunkAtPosition(p)
   var ckey = c.join('|')
   var chunk = self.voxels.chunks[ckey]
   if (!chunk) return false
-  
+
   var pos = self.controls.yawObject.position
   var collisions = self.getCollisions(pos, {
     width: self.cubeSize / 2,
     depth: self.cubeSize / 2,
     height: self.cubeSize * 1.5
   }, check)
-  
+
   if (collisions.top.length) return false
   if (collisions.middle.length) return false
   if (collisions.bottom.length > 2) return false
-  
+
   function check(v) { return vidx === self.voxels.voxelIndexFromPosition(v) }
-  
+
   return {chunkIndex: ckey, voxelVector: voxelVector}
 }
 
@@ -483,19 +471,9 @@ Game.prototype.showChunk = function(chunk) {
   else mesh.createSurfaceMesh(this.material)
   mesh.setPosition(bounds[0][0] * cubeSize, bounds[0][1] * cubeSize, bounds[0][2] * cubeSize)
   mesh.addToScene(this.scene)
-  this.applyTextures(mesh.geometry)
+  this._materialEngine.applyTextures(mesh.geometry)
   this.items.forEach(function (item) { item.resting = false })
   return mesh
-}
-
-Game.prototype.applyTextures = function (geom) {
-  var self = this;
-  
-  geom.faces.forEach(function (face, ix) {
-    var c = face.vertexColors[0]
-    var index = Math.floor(c.b*255 + c.g*255*255 + c.r*255*255*255)
-    face.materialIndex = Math.max(0, index - 1) % self.materials.length
-  })
 }
 
 Game.prototype.calculateFreedom = function(cs, pos) {
@@ -503,48 +481,48 @@ Game.prototype.calculateFreedom = function(cs, pos) {
     'x+': true, 'y+': true, 'z+': true,
     'x-': true, 'y-': true, 'z-': true
   }
-  
+
   freedom['y+'] = cs.top.length === 0
   freedom['y-'] = cs.bottom.length === 0
-  
+
   if (cs.left.length) freedom['x+'] = false
   if (cs.right.length) freedom['x-'] = false
   if (cs.up.length) freedom['y+'] = false
   if (cs.down.length) freedom['y-'] = false
   if (cs.forward.length) freedom['z-'] = false
   if (cs.back.length) freedom['z+'] = false
-  
+
   return freedom
 }
 
 Game.prototype.updatePlayerPhysics = function(controls) {
   var self = this
-  
+
   var pos = controls.yawObject.position.clone()
   pos.y -= this.cubeSize
-  
+
   var cs = this.getCollisions(pos, {
     width: this.cubeSize / 2,
     depth: this.cubeSize / 2,
     height: this.cubeSize * 1.5
   }, false, controls)
   var freedom = this.calculateFreedom(cs, pos)
-  
+
   var degrees = 0
   Object.keys(freedom).forEach(function (key) { degrees += freedom[key] })
   controls.freedom = degrees === 0 ? controls.freedom : freedom
-  
+
   var ry = this.controls.yawObject.rotation.y
   var v = controls.velocity
   var mag = 1
-  
+
   if (cs.left.length && !cs.right.length) {
     controls.yawObject.position.x += mag * Math.cos(ry - Math.PI / 2)
   }
   if (cs.right.length && !cs.left.length) {
     controls.yawObject.position.x += mag * Math.cos(ry + Math.PI / 2)
   }
-  
+
   if (cs.forward.length && !cs.back.length) {
     controls.yawObject.position.z += mag * Math.sin(ry)
   }

--- a/package.json
+++ b/package.json
@@ -14,17 +14,16 @@
     "three": "0.54.0",
     "raf": "0.0.1",
     "interact": "0.0.2",
-    "toolbar": "0.0.2"
+    "toolbar": "0.0.2",
+    "voxel-texture": "~0.2.0"
   },
   "devDependencies": {
-    "minecraft-skin": "0.0.1"
+    "minecraft-skin": "0.0.1",
+    "ecstatic": "0.3.0"
   },
   "scripts": {
     "start": "node server.js",
     "make": "mkdir -p dist && browserify demo/demo.js > dist/browserify-bundle.js",
     "watch": "mkdir -p dist && browserify demo/demo.js -o dist/browserify-bundle.js --watch --debug"
-  },
-  "devDependencies": {
-    "ecstatic": "0.3.0"
   }
 }


### PR DESCRIPTION
This will allow voxels within voxel meshes to have different sided textures. Materials can be specified as such:

``` js
// first is block with grass on top
// dirt on the bottom and grass_dirt on the sides
// the other blocks have the same texture on all sides
materials: [
  ['grass', 'dirt', 'grass_dirt'],
  'brick', 'dirt', 'obsidian', 'crate'
]
```

The various shorthand ways to set the faces of the texture can be viewed here: https://github.com/shama/voxel-texture

The only issue now is the front and left sides have their textures rotated 90deg. Looking into a fix now that will land is voxel-texture@0.2.1.

Thanks!
