### PR TITLE
Restore texture api: loadTextures and applyTextures

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -66,7 +66,7 @@ Game.prototype.initializeRendering = function() {
     texturePath: self.texturePath,
     THREE: THREE
   })
-  this.material = this._materialEngine.loadTextures(this.materials)
+  this.material = this.loadTextures(this.materials)
   this.renderer = this.createRenderer()
   this.addLights(this.scene)
   this.bindWASD(this.controls)
@@ -244,6 +244,14 @@ Game.prototype.raycast = function() {
   var direction = this.camera.matrixWorld.multiplyVector3(new THREE.Vector3(0,0,-1))
   var intersects = this.intersectAllMeshes(start, direction)
   return intersects
+}
+
+Game.prototype.loadTextures = function (names) {
+  return this._materialEngine.loadTextures(names)
+}
+
+Game.prototype.applyTextures = function (geom) {
+  this._materialEngine.applyTextures(geom)
 }
 
 Game.prototype.createCamera = function() {
@@ -479,7 +487,7 @@ Game.prototype.showChunk = function(chunk) {
   else mesh.createSurfaceMesh(this.material)
   mesh.setPosition(bounds[0][0] * cubeSize, bounds[0][1] * cubeSize, bounds[0][2] * cubeSize)
   mesh.addToScene(this.scene)
-  this._materialEngine.applyTextures(mesh.geometry)
+  this.applyTextures(mesh.geometry)
   this.items.forEach(function (item) { item.resting = false })
   return mesh
 }


### PR DESCRIPTION
I removed `loadTextures` and `applyTextures` in my last commit but I realized they should probably still be exposed. Rather than each app needing `voxel-texture` required to texture things. This way voxel creature [can be obsidian](https://github.com/substack/voxel-creature/blob/master/example/debris.js#L31) once again.
