### PR TITLE
Make `demo` the root directory for `npm start`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "browservefy": "0.0.0"
   },
   "scripts": {
-    "start": "echo \"open localhost:8080/demo/\" && ./node_modules/browservefy/bin/browservefy demo/demo.js 8080 -- -d"
+    "start": "echo \"open localhost:8080/\" && cd demo && ../node_modules/.bin/browservefy demo.js 8080 -- -d"
   }
 }


### PR DESCRIPTION
The demo wasn't running properly according to the instructions in the readme - URLs in the script/HTML weren't resolving properly when running from `localhost:8080/demo`. Tiny fix but should help people getting started :)
