### PR TITLE
'Fixes' an issue changing material back to grass

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -25,6 +25,7 @@ var currentMaterial = 1
 
 blockSelector.on('select', function(material) {
   var idx = game.materials.indexOf(material)
+  if (idx === -1 && game.materials[0].indexOf(material) !== -1) idx = 0
   if (idx > -1) currentMaterial = idx + 1
 })
 


### PR DESCRIPTION
```
materials: [['grass', 'dirt', 'grass_dirt'], 'brick', 'dirt', 'obsidian', 'crate'],
```

Doesn't allow you to change back to grass, as it's an inner array.
I've just put in something to check that first inner array, can work on a better solution.

Is a for loop to check if each of the array values have inner arrays, the best way?
