### PR TITLE
Use `collide-3d-tilemap` for collisions

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -8,6 +8,8 @@ var playerPhysics = require('player-physics')
 var requestAnimationFrame = require('raf')
 var inherits = require('inherits')
 var EventEmitter = require('events').EventEmitter
+var collisions = require('collide-3d-tilemap')
+var aabb = require('aabb-3d')
 
 module.exports = Game
 
@@ -48,6 +50,12 @@ function Game(opts) {
   this.camera = this.createCamera(scene)
   this.controls = this.createControls()
   this.moveToPosition(this.startingPosition)
+  this.collideVoxels = collisions(
+    this.getTileAtIJK.bind(this),
+    this.cubeSize,
+    [Infinity, Infinity, Infinity],
+    [-Infinity, -Infinity, -Infinity]
+  )
 
   // client side only (todo: use better pattern than this)
   if (process.browser) {
@@ -59,6 +67,55 @@ function Game(opts) {
 }
 
 inherits(Game, EventEmitter)
+
+Game.prototype.getTileAtIJK = function(i, j, k) {
+  var pos = this.tilespaceToWorldspace(i, j, k)
+  // TODO: @chrisdickinson: cache the chunk lookup by `i|j|k`
+  // since we'll be seeing the same chunk so often
+  var chunk = this.getChunkAtPosition(pos)
+
+  if(!chunk) {
+    return
+  }
+
+  var chunkPosition = this.chunkspaceToTilespace(chunk.position)
+  var chunkID = this.voxels.chunkAtPosition(pos).join('|') 
+  var chunk = this.voxels.chunks[chunkID]
+   
+  i -= chunkPosition.i
+  j -= chunkPosition.j
+  k -= chunkPosition.k
+
+  var tileOffset = 
+    i +
+    j * this.chunkSize +
+    k * this.chunkSize * this.chunkSize
+
+  return chunk.voxels[tileOffset] 
+}
+
+Game.prototype.tilespaceToWorldspace = function(i, j, k) {
+  return {
+    x: i * this.cubeSize,
+    y: j * this.cubeSize,
+    z: k * this.cubeSize
+  }
+}
+
+Game.prototype.chunkspaceToTilespace = function(pos) {
+  return {
+    i: pos[0] * this.chunkSize,
+    j: pos[1] * this.chunkSize,
+    k: pos[2] * this.chunkSize
+  }
+}
+
+Game.prototype.getChunkAtPosition = function(pos) {
+  var chunkID = this.voxels.chunkAtPosition(pos).join('|') 
+
+  var chunk = this.voxels.chunks[chunkID]
+  return chunk
+}
 
 Game.prototype.initializeRendering = function() {
   var self = this
@@ -513,38 +570,53 @@ Game.prototype.calculateFreedom = function(cs, pos) {
 
 Game.prototype.updatePlayerPhysics = function(controls) {
   var self = this
+ 
+  var pos = controls.yawObject.position
 
-  var pos = controls.yawObject.position.clone()
-  pos.y -= this.cubeSize
+  var bbox = aabb(
+        [ pos.x - this.cubeSize / 4
+        , pos.y - this.cubeSize * 1.5
+        , pos.z - this.cubeSize / 4 ]
+      , [this.cubeSize / 2, this.cubeSize * 1.5, this.cubeSize / 2]
+      )
+    , base = [this.controls.yawObject.position.x, this.controls.yawObject.position.y, this.controls.yawObject.position.z]
+    , user_vec = [this.controls.velocity.x, this.controls.velocity.y, this.controls.velocity.z]
+    , world_vec
 
-  var cs = this.getCollisions(pos, {
-    width: this.cubeSize / 2,
-    depth: this.cubeSize / 2,
-    height: this.cubeSize * 1.5
-  }, false, controls)
-  var freedom = this.calculateFreedom(cs, pos)
+  this.controls.yawObject.translateX(user_vec[0])
+  this.controls.yawObject.translateY(user_vec[1])
+  this.controls.yawObject.translateZ(user_vec[2])
 
-  var degrees = 0
-  Object.keys(freedom).forEach(function (key) { degrees += freedom[key] })
-  controls.freedom = degrees === 0 ? controls.freedom : freedom
+  world_vec = [this.controls.yawObject.position.x - base[0]
+  , this.controls.yawObject.position.y - base[1]
+  , this.controls.yawObject.position.z - base[2]]
 
-  var ry = this.controls.yawObject.rotation.y
-  var v = controls.velocity
-  var mag = 1
+  this.controls.yawObject.translateX(-user_vec[0])
+  this.controls.yawObject.translateY(-user_vec[1])
+  this.controls.yawObject.translateZ(-user_vec[2])
 
-  if (cs.left.length && !cs.right.length) {
-    controls.yawObject.position.x += mag * Math.cos(ry - Math.PI / 2)
+  function sign(x) {
+    return x / Math.abs(x)
   }
-  if (cs.right.length && !cs.left.length) {
-    controls.yawObject.position.x += mag * Math.cos(ry + Math.PI / 2)
-  }
 
-  if (cs.forward.length && !cs.back.length) {
-    controls.yawObject.position.z += mag * Math.sin(ry)
-  }
-  if (cs.back.length && !cs.forward.length) {
-    controls.yawObject.position.z += mag * Math.sin(ry - Math.PI)
-  }
+  self.controls.freedom['y-'] = true
+
+  this.collideVoxels(bbox, world_vec, function(axis, tile, coords, dir, edge_vector) {
+    if(tile) {
+      world_vec[axis] = edge_vector
+      if(axis === 1 && dir === -1) {
+        self.controls.freedom['y-'] = false
+      }
+      return true
+    }
+  })  
+
+  this.controls.velocity.x = 0 
+  this.controls.velocity.y = 0
+  this.controls.velocity.z = 0
+  this.controls.yawObject.position.x = world_vec[0] + base[0]
+  this.controls.yawObject.position.y = world_vec[1] + base[1]
+  this.controls.yawObject.position.z = world_vec[2] + base[2] 
 }
 
 Game.prototype.bindWASD = function (controls) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "raf": "0.0.1",
     "interact": "0.0.2",
     "toolbar": "0.0.2",
-    "voxel-texture": "0.2.1"
+    "voxel-texture": "0.2.1",
+    "collide-3d-tilemap": "0.0.1"
   },
   "devDependencies": {
     "minecraft-skin": "0.0.1",


### PR DESCRIPTION
There'll be a corresponding pull request on `player-physics` since this mucks about with unit sizes there (inadvertantly, I swear).

[here's a demo](http://neversaw.us/voxel/)

some notes:
- we have to translate out of modelspace (from `controls.velocity`) to worldspace to get an accurate vector to feed to `collide-3d-tilemap`. this is ugly.
- we sidestep a lot of `player-physics` because of this -- essentially we have to zero out the vector each step because we don't want `player-physics` to move the viewport.
- the other downside is that it breaks jumping (the up portion of the jump is instantaneous, not smooth). we could fix it making "jump" a polling API instead of an event-based one, maybe.
