### PR TITLE
Fix ref to THREE in UpdatePlayerPhysics

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -609,7 +609,7 @@ Game.prototype.updatePlayerPhysics = function(controls) {
     }
   })  
   
-  var newLocation = new game.THREE.Vector3(
+  var newLocation = new THREE.Vector3(
     worldVector[0] + base[0], worldVector[1] + base[1], worldVector[2] + base[2]
   )
   pos.copy(newLocation)


### PR DESCRIPTION
Small fix in updatePlayerPhysics. `game.THREE` is not defined there. Should just be `THREE`.
