### PR TITLE
Custom block materials

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -41,6 +41,8 @@ function Game(opts) {
   this.meshType = opts.meshType || 'surfaceMesh'
   this.controlOptions = opts.controlOptions || {}
   this.materials = opts.materials || [['grass', 'dirt', 'grass_dirt'], 'brick', 'dirt']
+  this.materialType = opts.materialType || THREE.MeshLambertMaterial
+  this.materialParams = opts.materialParams || {}
   this.items = []
   this.voxels = voxel(this)
   this.voxels.generateMissingChunks(this.worldOrigin)
@@ -121,6 +123,8 @@ Game.prototype.initializeRendering = function() {
   var self = this
   this._materialEngine = require('voxel-texture')({
     texturePath: self.texturePath,
+    materialType: self.materialType,
+    materialParams: self.materialParams,
     THREE: THREE
   })
   this.material = this.loadTextures(this.materials)
@@ -303,8 +307,8 @@ Game.prototype.raycast = function() {
   return intersects
 }
 
-Game.prototype.loadTextures = function (names) {
-  return this._materialEngine.loadTextures(names)
+Game.prototype.loadTextures = function (names, opts) {
+  return this._materialEngine.loadTextures(names, opts)
 }
 
 Game.prototype.applyTextures = function (geom) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "raf": "0.0.1",
     "interact": "0.0.2",
     "toolbar": "0.0.2",
-    "voxel-texture": "0.2.1",
+    "voxel-texture": "0.2.2",
     "collide-3d-tilemap": "0.0.1",
     "aabb-3d": "0.0.0"
   },


### PR DESCRIPTION
Based on the changes made in shama/voxel-texture#4, this enables two additional parameters for the game constructor: `materialType` and `materialParams`, which allow you to specify the default materials to use and alter their behaviour.

This means it _could_ be pretty straightforward dropping in shaders for day/night transitions, warping terrain, etc. Unfortunately this only applies to the voxels at the moment (see below).

It'd be interesting to have a more flexible "base" material than `MeshLambertMaterial` which other modules could use or extend. Maybe there's a better way to go about it though, I'm not sure :)

![Screen Shot 2013-01-23 at 12 00 44 AM](https://f.cloud.github.com/assets/569817/86321/ce108f40-6495-11e2-8c48-e4e1085f7aa8.png)
