### PR TITLE
Bump spatial-events req

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "voxel-texture": "0.2.2",
     "collide-3d-tilemap": "0.0.1",
     "aabb-3d": "0.0.0",
-    "spatial-events": "0.0.0",
+    "spatial-events": ">=0.0.1",
     "spatial-trigger": "0.0.0"
   }
 }


### PR DESCRIPTION
Recent changes fix a fairly gnarly bug in the octree generation.

Went with >= 0.0.1 because:
1. I want to add a method to limit the maximum number of octree nodes
2. I want octree nodes to garbage collect themselves once they're empty (with an optional "ee.gc()" to detach all references to orphaned nodes
3. I want to make it simple to "move" listeners over time.
