### PR TITLE
Add Game.prototype.render()

### DIFF
--- a/index.js
+++ b/index.js
@@ -717,9 +717,13 @@ Game.prototype.tick = function(delta) {
   })
   this.items.forEach(function (item) { item.tick(delta) })
   this.emit('tick', delta)
-  this.renderer.render(this.scene, this.camera)
+  this.render(delta)
   stats.update()
 }
+
+Game.prototype.render = function(delta) {
+  this.renderer.render(this.scene, this.camera)
+};
 
 function distance (a, b) {
   var x = a.x - b.x


### PR DESCRIPTION
Nearly ready with a GLSL post-processing module for voxel.js, but I need to be able to override the default render call for `Game` - this should do the trick :)

This way you can just do:

``` javascript
var game = require('voxel-engine')()
game.render = function() {
  // some other things instead
};
```
