### PR TITLE
Update materials API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-engine",
   "description": "make games with voxel.js",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "repository": {
     "type":"git",
     "url": "git@github.com:maxogden/voxel-engine.git"
@@ -16,7 +16,7 @@
     "raf": "0.0.1",
     "interact": "0.0.2",
     "toolbar": "0.0.2",
-    "voxel-texture": "0.2.2",
+    "voxel-texture": "0.3.0",
     "voxel-region-change": "0.0.2",
     "collide-3d-tilemap": "0.0.1",
     "aabb-3d": "0.0.0",


### PR DESCRIPTION
I've refactored `voxel-texture@0.3.0` with a better API for managing materials. This streamlines the materials API to one endpoint: `game.materials`.

Materials can still be loaded like:

``` js
var game = createEngine({
  materials: ['brick', ['grass', 'dirt', 'grass_dirt']],
  texturePath: './textures/'
})
```

Later additional materials can be loaded:

``` js
game.materials.load([
  'obsidian',
  ['tree_top', 'tree_sides'],
  new THREE.Texture(customCanvasTexture)
])
```

With each load, materials are added to a `materialIndex`. So materials can be retrieved with `get()`:

``` js
// by the material index number
var obsidian = game.materials.get(2)
// [obsidian, obsidian, obsidian, obsidian, obsidian, obsidian]

// or by name which finds the first matching texture
// and returns that material block
var grass = game.materials.get('grass')
// [grass_dirt, grass_dirt, grass, dirt, grass_dirt, grass_dirt]

// or just retrieve all loaded materials
var all = game.materials.get()
```

Also `game.applyTextures(geom)` -> `game.materials.paint(geom)`.

This change breaks everyone's code but I think it's worth it to simplify the material management down to one endpoint.

voxel-texure now has `sprite` for chopping up sprite sheets into textures:

``` js
// load a 512x512 image
// each sprite is 32x32
game.materials.sprite('terrain', 32, function(err, textures) {
  game.materials.load(textures)
  // with each material named 'terrain_x_y'
})
```

Full docs here: https://github.com/shama/voxel-texture

Thanks!
