### PR TITLE
Run materials.tick for animated materials

### DIFF
--- a/index.js
+++ b/index.js
@@ -738,6 +738,7 @@ Game.prototype.tick = function(delta) {
     self.updatePlayerPhysics(bbox, controls)
   })
   this.items.forEach(function (item) { item.tick(delta) })
+  if (this.materials) this.materials.tick()
   this.emit('tick', delta)
   this.render(delta)
   stats.update()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-engine",
   "description": "make games with voxel.js",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "repository": {
     "type":"git",
     "url": "git@github.com:maxogden/voxel-engine.git"
@@ -16,7 +16,7 @@
     "raf": "0.0.1",
     "interact": "0.0.2",
     "toolbar": "0.0.2",
-    "voxel-texture": "0.3.0",
+    "voxel-texture": "0.3.1",
     "voxel-region-change": "0.0.2",
     "collide-3d-tilemap": "0.0.1",
     "aabb-3d": "0.0.0",


### PR DESCRIPTION
`voxel-texture@0.3.1` now offers animated materials by passing `animate` an array of loaded materials to cycle and a delay:

``` js
var animated = game.materials.animate(['grass', 'obsidian', 'brick'], 1000);

var mesh = new game.THREE.Mesh(
  new game.THREE.CubeGeometry(game.cubeSize, game.cubeSize, game.cubeSize),
  new game.THREE.MeshFaceMaterial([
    animated, animated, animated, animated, animated, animated
  ])
);
```

`game.materials.tick()` runs the actual animations if there are any. Better example here: https://github.com/shama/voxel-texture/blob/master/example/world.js#L111 and here: http://shama.github.com/voxel-texture/
