### PR TITLE
Clean up voxel chunks more thoroughly

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,15 @@ Game.prototype.removeFarChunks = function(playerPosition) {
   })
   Object.keys(self.voxels.chunks).map(function(chunkIndex) {
     if (nearbyChunks.indexOf(chunkIndex) > -1) return
-    self.scene.remove(self.voxels.meshes[chunkIndex][self.meshType])
+    var chunk = self.voxels.meshes[chunkIndex]
+
+    self.scene.remove(chunk[self.meshType])
+    chunk[self.meshType].geometry.dispose()
+
+    delete chunk.data
+    delete chunk.geometry
+    delete chunk.meshed
+    delete chunk.surfaceMesh
     delete self.voxels.chunks[chunkIndex]
   })
   self.voxels.requestMissingChunks(playerPosition)


### PR DESCRIPTION
I was checking out the infinite terrain, but the game would freeze after hitting 600-700MB memory usage. Turns out you have to [deallocate geometries/textures/shaders/etc. manually](http://stackoverflow.com/questions/12945092/memory-leak-with-three-js-and-many-shapes).

After that, deleting the properties of the chunk mesh seemed to do the trick - the game still hits ~600MB but doesn't freeze anymore :)
