### PR TITLE
Updating flat world example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This places the player just above the ground.
 ```js
 var game = createGame({
   generate: function(i,j,k) {
-    return j < 1 ? 1 : 0;
+    return j === 1 ? 1 : 0;
   }
 })
 


### PR DESCRIPTION
I updated the flat world readme example. `j < 1` creates tons of
boxes that are unnecessary and wrecked the framerate on my very old laptop. `j === 1` runs like a dream.
