### PR TITLE
Don't throw errors if no player is set up to control.

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,10 +299,19 @@ Game.prototype.potentialCollisionSet = function() {
   return [{ collide: this.collideTerrain.bind(this) }]
 }
 
+/**
+ * Get the position of the player under control.
+ * If there is no player under control, return
+ * current position of the game's camera.
+ *
+ * @return {Array} an [x, y, z] tuple
+ */
+
 Game.prototype.playerPosition = function() {
   var target = this.controls.target()
-  if (!target) return false
-  var position = target.avatar.position
+  var position = target
+    ? target.avatar.position
+    : this.camera.localToWorld(this.camera.position)
   return [position.x, position.y, position.z]
 }
 


### PR DESCRIPTION
if there's no `this.controls.target()`, `game.playerPosition()` returns `false`, yet all the methods that use `game.playerPosition()` ignore this possibility, thus, if you don't set up an object to control, the engine becomes unhappy. 

This gives the engine a sensible default in lieu of a real player position (the `game.camera.position`). 
