### PR TITLE
Return item after addItem

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ Game.prototype.addItem = function(item) {
   
   this.items.push(item)
   if (item.mesh) this.scene.add(item.mesh)
+  return this.items[this.items.length - 1]
 }
 
 Game.prototype.removeItem = function(item) {

--- a/test.js
+++ b/test.js
@@ -30,9 +30,11 @@ test('create, destroy', function (t) {
 })
 
 gameTest(function addItem(game, t) {
+  t.plan(2)
   var item = { tick: function(){} }
-  game.addItem(item)
+  var newItem = game.addItem(item)
   t.equal(game.items.length, 1)
+  t.equal(newItem, game.items[game.items.length - 1])
 })
 
 gameTest(function removeItem(game, t) {


### PR DESCRIPTION
This will return the item after calling `game.addItem(item)`. To more easily access the item if you are using it to create a physical item.
