### PR TITLE
Use game.materials.findIndex to find correct block type. Bump v0.16.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ Game.prototype.canCreateBlock = function(pos) {
 }
 
 Game.prototype.createBlock = function(pos, val) {
-  if (typeof val === 'string') val = this.materials.find(val) + 1
+  if (typeof val === 'string') val = this.materials.findIndex(val)
   if (pos.chunkMatrix) return this.chunkGroups.createBlock(pos, val)
   if (!this.canCreateBlock(pos)) return false
   this.setBlock(pos, val)
@@ -227,7 +227,7 @@ Game.prototype.createBlock = function(pos, val) {
 }
 
 Game.prototype.setBlock = function(pos, val) {
-  if (typeof val === 'string') val = this.materials.find(val) + 1
+  if (typeof val === 'string') val = this.materials.findIndex(val)
   if (pos.chunkMatrix) return this.chunkGroups.setBlock(pos, val)
   var old = this.voxels.voxelAtPosition(pos, val)
   var c = this.voxels.chunkAtPosition(pos)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-engine",
   "description": "make games with voxel.js",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "repository": {
     "type": "git",
     "url": "git@github.com:maxogden/voxel-engine.git"
@@ -13,7 +13,7 @@
     "voxel-chunks": "0.0.2",
     "voxel-raycast": "0.2.1",
     "voxel-control": "0.0.7",
-    "voxel-texture": "0.3.3",
+    "voxel-texture": "0.4.0",
     "voxel-physical": "0.0.8",
     "voxel-region-change": "0.1.0",
     "raf": "0.0.1",

--- a/test.js
+++ b/test.js
@@ -54,11 +54,14 @@ gameTest(function setBlock(game, t) {
 })
 
 gameTest(function setBlockWithMaterialName(game, t) {
-  game.materials.materials = [
-    { name: 'grass' },
-    { name: 'brick' },
-    { name: 'dirt' },
-  ]
+  // simulate a game.materials.load
+  ['grass', 'brick', 'dirt'].forEach(function(material, idx) {
+    for (var i = 0; i < 6; i++) {
+      game.materials.materials.push({name: material})
+    }
+    idx *= 6
+    game.materials.materialIndex.push([idx, idx + 6])
+  })
   game.setBlock([50, 50, 50], 'brick')
   t.equal(game.getBlock([50, 50, 50]), 2)
 })


### PR DESCRIPTION
`game.materials.find('name')` will return the actual index of the found material within `game.materials` but not the block type index.

So I added a new method to voxel-texture to fix this called `game.materials.findIndex('name')` and updated the test to simulate how textures are loaded into the materials API more closely.

Now doing `game.setBlock([0, 0, 0], 'coal')` will work correctly. My mistake!
