### PR TITLE
Update to voxel-texture v0.5.0 which uses texture atlases. Bump v0.17.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,17 +233,11 @@ For example, here we have 4 faces colliding with the bottom of our object:
 
 ### Textures
 
-Loading textures creates multiple "materials".
+Loading textures onto the texture atlas.
 
-```var materials = game.materials.load(['obsidian', 'dirt'])```
+```game.materials.load(['obsidian', 'dirt'], function(textures) { })```
 
-Both of these textures come with 6 materials, one for each side of a cube, giving a total of 12 materials. By default, faces 1 to 6 are assigned materials 1 to 6. You can assign materials to faces in however you want. For example, we could load materials 7 to 12 (e.g. the dirt materials) like so:
-
-```js
-mesh.geometry.faces.forEach(function (face, index) {
-  face.materialIndex = index + 6 // obsidian texture indices 0 - 5, dirt 6 - 11
-})
-```
+Both of these textures will be loaded into the texture atlas and expanded creating 2 voxel block types.
 
 ### Items
 
@@ -255,14 +249,14 @@ mesh.geometry.faces.forEach(function (face, index) {
 ####  Example:  Creating an Item
 
 ```js
-// get a previously loaded texture by name
-var material = game.materials.get('obsidian');
-
-// create a mesh and set the matertial
+// create a mesh and set the matertial of the texture atlas
 var mesh = new game.THREE.Mesh(
   new game.THREE.CubeGeometry(10, 30, 10), // width, height, depth
-  new game.THREE.MeshFaceMaterial(material)
+  game.materials.material
 );
+
+// paint the mesh with a previously loaded texture
+game.materials.paint(mesh, 'obsidian')
 
 // move item to some location
 mesh.translateX(87.5)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-engine",
   "description": "make games with voxel.js",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:maxogden/voxel-engine.git"
@@ -13,7 +13,7 @@
     "voxel-chunks": "0.0.2",
     "voxel-raycast": "0.2.1",
     "voxel-control": "0.0.7",
-    "voxel-texture": "0.4.0",
+    "voxel-texture": "0.5.0",
     "voxel-physical": "0.0.8",
     "voxel-region-change": "0.1.0",
     "raf": "0.0.1",


### PR DESCRIPTION
Updates to support voxel-texture v0.5.0 which now loads everything onto a texture atlas and sets UV mappings.

Increases performance roughly by 10 fold. voxel-texture has just about been re-written and is not backwards compatible so I've bumped voxel engine a minor version.

Previously this scene with `chunkDistance: 6` never would run above `7fps` on my macbook but now runs around `30fps` :D
![screen_2013-04-15](https://f.cloud.github.com/assets/99604/383340/1c50bd14-a614-11e2-8a44-2d4510c064fe.png)
