### PR TITLE
Enable materialFlatColor option

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ function Game(opts) {
     game: this,
     texturePath: opts.texturePath || './textures/',
     materialType: opts.materialType || THREE.MeshLambertMaterial,
-    materialParams: opts.materialParams || {}
+    materialParams: opts.materialParams || {},
+    materialFlatColor: opts.materialFlatColor === true
   })
 
   this.materialNames = opts.materials || [['grass', 'dirt', 'grass_dirt'], 'brick', 'dirt']

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-engine",
   "description": "make games with voxel.js",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:maxogden/voxel-engine.git"
@@ -13,7 +13,7 @@
     "voxel-chunks": "0.0.2",
     "voxel-raycast": "0.2.1",
     "voxel-control": "0.0.7",
-    "voxel-texture": "0.5.4",
+    "voxel-texture": "0.5.6",
     "voxel-physical": "0.0.8",
     "voxel-region-change": "0.1.0",
     "raf": "0.0.1",


### PR DESCRIPTION
![screen shot 2013-06-03 at 11 25 06 pm](https://f.cloud.github.com/assets/99604/603925/1de6db56-cce1-11e2-8c1a-e2934b10c5d4.png)

voxel-texture@0.5.6 now has a `materialFlatColor` option. This will disable textures and use `new this.THREE.MeshBasicMaterial({vertexColors: this.THREE.VertexColors})`.

You can specify colors in the materials array:

``` js
var game = createGame({
  //materials: ['brick', ['grass', 'dirt', 'grass_dirt'], 'dirt'],
  materials: ['#E04006', '#C0D890', '#8A360F'],
  materialFlatColor: true
})
```

The AO isn't that great but I'll make it better in time. Thanks!
