### PR TITLE
New option 'interactMouseDrag', which if set to true doesn't steal the mouse control

### DIFF
--- a/index.js
+++ b/index.js
@@ -677,7 +677,7 @@ Game.prototype.initializeControls = function(opts) {
   this.buttons = kb(document.body, this.keybindings)
   this.buttons.disable()
   this.optout = false
-  this.interact = interact(opts.interactElement || this.view.element)
+  this.interact = interact(opts.interactElement || this.view.element, opts.interactMouseDrag)
   this.interact
       .on('attain', this.onControlChange.bind(this, true))
       .on('release', this.onControlChange.bind(this, false))


### PR DESCRIPTION
We will need something like this for FF Tactics like games. If it isn't specified, it will behave as previously, but if set to true, it won't steal the cursor and mouse controls.
