### PR TITLE
Support dynamically changing mesh type at runtime 

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,8 +112,8 @@ function Game(opts) {
   
   this.paused = true
   this.initializeRendering(opts)
-  
-  for (var chunkIndex in this.voxels.chunks) this.showChunk(this.voxels.chunks[chunkIndex])
+ 
+  this.showAllChunks()
 
   setTimeout(function() {
     self.asyncChunkGeneration = 'asyncChunkGeneration' in opts ? opts.asyncChunkGeneration : true
@@ -538,6 +538,12 @@ Game.prototype.getChunkAtPosition = function(pos) {
   var chunkID = this.voxels.chunkAtPosition(pos).join('|')
   var chunk = this.voxels.chunks[chunkID]
   return chunk
+}
+
+Game.prototype.showAllChunks = function() {
+  for (var chunkIndex in this.voxels.chunks) {
+    this.showChunk(this.voxels.chunks[chunkIndex])
+  }
 }
 
 Game.prototype.showChunk = function(chunk) {


### PR DESCRIPTION
Allows the meshing type to be changed live, for example:

```
game.meshType = 'wireFrame'
game.showAllChunks()
```

to switch all chunks from surface meshes to wire framing, no reloading needed:

![e19903303b641faced67c456aa5f280c](https://f.cloud.github.com/assets/5897956/1811852/26653f96-6e64-11e3-81d9-bb6ca79b83d1.gif)

Useful for testing different meshing algorithms (game.mesher can already be changed at runtime without issue).
