### PR TITLE
Add arrayTypeSize option, alternative to passing constructor in arrayType

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function Game(opts) {
   this.THREE = THREE
   this.vector = vector
   this.glMatrix = glMatrix
-  this.arrayType = opts.arrayType || Uint8Array
+  this.arrayType = opts.arrayType || {1:Uint8Array, 2:Uint16Array, 4:Uint32Array}[opts.arrayTypeSize] || Uint8Array
   this.cubeSize = 1 // backwards compat
   this.chunkSize = opts.chunkSize || 32
   


### PR DESCRIPTION
The 'arrayType' option allows the type of the array for voxels to be configured, but it requires passing a constructor - problematic in some situations since it cannot be directly JSON serialized. For example, voxel-client/voxel-server sends the voxel-engine settings over the network as JSON, or other modules may want to otherwise persist these settings, but `arrayType: Uint16Array` doesn't make it through.

So this PR adds an alternative option, arrayTypeSize - an easily-serializable integer, representing the number of bytes for the typed array (1, 2, or 4 for Uint8Array, Uint16Array, or Uint32Array, respectively).
