### PR TITLE
Fix invalid JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "contributors": [
     "Max Ogden <max@maxogden.com> (https://github.com/maxogden)",
     "Kumavis <a.aa.akio.aaron@gmail.com> (https://github.com/kumavis)",
-    "Deathcap <deathcap@gmx.co.uk> (https://github.com/deathcap)",
+    "Deathcap <deathcap@gmx.co.uk> (https://github.com/deathcap)"
   ],
   "dependencies": {
     "voxel": "0.3.1",


### PR DESCRIPTION
Removes the superfluous trailing comma causing:

npm ERR! Failed to parse json
npm ERR! Unexpected token ]
npm ERR! File: voxeljs/voxel-engine/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! System Darwin 13.1.0
npm ERR! command "node" "/usr/local/bin/npm" "test"
npm ERR! cwd voxeljs/voxel-engine
npm ERR! node -v v0.10.21
npm ERR! npm -v 1.4.4
npm ERR! file voxeljs/voxel-engine/package.json
npm ERR! code EJSONPARSE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     voxeljs/voxel-engine/npm-debug.log
npm ERR! not ok code 0

cheers
